### PR TITLE
Potential fix for code scanning alert no. 6: Server-side request forgery

### DIFF
--- a/apps/webapp/__tests__/server/api/client.test.ts
+++ b/apps/webapp/__tests__/server/api/client.test.ts
@@ -82,8 +82,16 @@ describe('fetchAPI', () => {
       await expect(fetchAPI('/./foo')).rejects.toThrow('Invalid API endpoint');
     });
 
+    it('rejects an endpoint containing a dot segment in the middle (/foo/./bar)', async () => {
+      await expect(fetchAPI('/foo/./bar')).rejects.toThrow('Invalid API endpoint');
+    });
+
     it('rejects an endpoint containing a double-dot segment (/../)', async () => {
       await expect(fetchAPI('/../foo')).rejects.toThrow('Invalid API endpoint');
+    });
+
+    it('rejects an endpoint containing a double-dot segment in the middle (/foo/../bar)', async () => {
+      await expect(fetchAPI('/foo/../bar')).rejects.toThrow('Invalid API endpoint');
     });
 
     it('rejects a whitespace-only endpoint', async () => {

--- a/apps/webapp/__tests__/server/api/client.test.ts
+++ b/apps/webapp/__tests__/server/api/client.test.ts
@@ -48,4 +48,46 @@ describe('fetchAPI', () => {
       expect.objectContaining({ cache: 'no-store' })
     );
   });
+
+  describe('sanitizeApiEndpoint (SSRF prevention)', () => {
+    it('allows a valid absolute-path endpoint', async () => {
+      await expect(fetchAPI('/users')).resolves.toBeDefined();
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/users'),
+        expect.anything()
+      );
+    });
+
+    it('rejects an empty endpoint', async () => {
+      await expect(fetchAPI('')).rejects.toThrow('Invalid API endpoint');
+    });
+
+    it('rejects an endpoint with a protocol (http://)', async () => {
+      await expect(fetchAPI('http://evil.com/path')).rejects.toThrow('Invalid API endpoint');
+    });
+
+    it('rejects an endpoint with a protocol (https://)', async () => {
+      await expect(fetchAPI('https://evil.com/path')).rejects.toThrow('Invalid API endpoint');
+    });
+
+    it('rejects a protocol-relative URL (//evil.com)', async () => {
+      await expect(fetchAPI('//evil.com/path')).rejects.toThrow('Invalid API endpoint');
+    });
+
+    it('rejects an endpoint without a leading slash', async () => {
+      await expect(fetchAPI('relative/path')).rejects.toThrow('Invalid API endpoint');
+    });
+
+    it('rejects an endpoint containing a dot segment (/./)', async () => {
+      await expect(fetchAPI('/./foo')).rejects.toThrow('Invalid API endpoint');
+    });
+
+    it('rejects an endpoint containing a double-dot segment (/../)', async () => {
+      await expect(fetchAPI('/../foo')).rejects.toThrow('Invalid API endpoint');
+    });
+
+    it('rejects a whitespace-only endpoint', async () => {
+      await expect(fetchAPI('   ')).rejects.toThrow('Invalid API endpoint');
+    });
+  });
 });

--- a/apps/webapp/server/api/client.ts
+++ b/apps/webapp/server/api/client.ts
@@ -25,10 +25,37 @@ function parseWebappSettings(value?: string): WebappSettings {
   }
 }
 
+function sanitizeApiEndpoint(endpoint: string): string {
+  const trimmed = endpoint.trim();
+
+  if (!trimmed) {
+    throw new Error('Invalid API endpoint');
+  }
+
+  // Disallow absolute/protocol-relative URLs to prevent SSRF.
+  if (trimmed.includes('://') || trimmed.startsWith('//')) {
+    throw new Error('Invalid API endpoint');
+  }
+
+  // Require absolute API path form.
+  if (!trimmed.startsWith('/')) {
+    throw new Error('Invalid API endpoint');
+  }
+
+  // Disallow dot-segments.
+  const segments = trimmed.split('/');
+  if (segments.some((segment) => segment === '.' || segment === '..')) {
+    throw new Error('Invalid API endpoint');
+  }
+
+  return trimmed;
+}
+
 export async function fetchAPI<T>(endpoint: string, params?: ApiParams): Promise<T> {
   const { smmRestBaseUrl } = getServerEnv();
   const apiBaseUrl = `${smmRestBaseUrl}/api/v1`;
-  const url = new URL(endpoint, apiBaseUrl);
+  const safeEndpoint = sanitizeApiEndpoint(endpoint);
+  const url = new URL(safeEndpoint, apiBaseUrl);
 
   // Append active project from cookie if set
   const cookieStore = await cookies();


### PR DESCRIPTION
Potential fix for [https://github.com/Side-Projects-4-Fun/software-metrics-machine/security/code-scanning/6](https://github.com/Side-Projects-4-Fun/software-metrics-machine/security/code-scanning/6)

General fix: enforce strict validation/normalization of `endpoint` before URL construction so only expected relative API paths are allowed, and reject absolute/protocol-relative URLs or malformed/path-traversal-like inputs.

Best fix in this file without changing intended functionality:
- In `apps/webapp/server/api/client.ts`, add a small sanitizer function (e.g., `sanitizeApiEndpoint`) that:
  - rejects empty values,
  - rejects `://` and leading `//` (prevents absolute/protocol-relative targets),
  - requires a leading `/`,
  - rejects `.` and `..` path segments.
- Use this sanitized value when constructing `new URL(...)` in `fetchAPI`.

This keeps current behavior for normal endpoints like `/users` while blocking SSRF vectors.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
